### PR TITLE
simgear.mk: Boost_USE_STATIC_LIBS=ON when ENABLE_TESTS=ON(default), u…

### DIFF
--- a/src/simgear.mk
+++ b/src/simgear.mk
@@ -28,7 +28,8 @@ define $(PKG)_BUILD
         -DPKG_CONFIG_EXECUTABLE='$(PREFIX)/bin/$(TARGET)-pkg-config' \
 		 $(if $(BUILD_STATIC), \
 		 -DSIMGEAR_SHARED=OFF \
-		 -DSYSTEM_EXPAT=OFF, \
+		 -DSYSTEM_EXPAT=OFF \
+		 -DBoost_USE_STATIC_LIBS=ON, \
 		 -DSIMGEAR_SHARED=ON \
 		 -DSYSTEM_EXPAT=ON)
     $(MAKE) -C '$(1).build' -j '$(JOBS)' install VERBOSE=1


### PR DESCRIPTION
Simgear static, tests for Boost fail by default, you need to define this variable Boost_USE_STATIC_LIBS to 'ON', because of this conditional, src/CMakeModules/BoostTestTargets.cmake:Line 77.

other wise it will include "BoostTestTargetsDynamic.h", which will build an object with shared declaration that fail to link in tests.

you can skip this with ENABLE_TEST=OFF, but this makes more sense for a more robust build.
